### PR TITLE
Catch case where target is not in .flyrc but no concourse_url was passed

### DIFF
--- a/fly
+++ b/fly
@@ -131,13 +131,15 @@ if target != "":
             if target_url != "" and cacert_file == "":
                 flyrc['targets'][target] = {
                     'api': target_url, 'token': {'type': 'Bearer', 'value': ''}}
-            if target_url != "" and cacert_file != "":
+            elif target_url != "" and cacert_file != "":
                 cacert = open(cacert_file, 'r').read()
                 flyrc['targets'][target] = {
                     'api': target_url, 'ca_cert': cacert, 'token': {'type': 'Bearer', 'value': ''}}
+            else:
+                raise Exception
         except Exception:
             print(
-                f"Unable to fetch target: {target} from $HOME/.flyrc .. Aborting")
+                f"Unable to fetch target: {target} from $HOME/.flyrc so cannot determine concourse_url.. Aborting")
             sys.exit(1)
     api_target = flyrc['targets'][target]['api']
     auth_token = flyrc['targets'][target]['token']['value']


### PR DESCRIPTION
* What is this PR for?
If you have an empty .flyrc (or the target is missing) when you attempt to do 'fly -t <target>' then you're dropped through to a python error.
```
Traceback (most recent call last):
  File "/Users/a591380/bin/fly", line 142, in <module>
    api_target = flyrc['targets'][target]['api']
KeyError: 'my-target'
```

This PR fixes that by catching empty target_url and raising exception with a more helpful error message.

* How to review
Move your .flyrc aside.
Try 'fly -t whevs pipelines' in master branch and then in this branch to see the difference.
Hit merge

* Who can review
Anyone but me.